### PR TITLE
[ci skip] ***NO_CI*** disable bot automerging

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,5 @@
 bot:
-  automerge: true
+  automerge: false
 conda_forge_output_validation: true
 github:
   branch_name: main


### PR DESCRIPTION
Upstream almost always updates dependency bounds with each release. CI tests don't catch this and so auto-merging leads to mismatched dependencies between source and build. This PR disables automerging in this feedstock.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
## Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Skipped CI
